### PR TITLE
Make shapefile creation functionized and filter out px values of 0 (no building detected).

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -277,7 +277,7 @@ def main():
     if args.create_shapefile:
         print('Creating shapefile')
         create_shapefile(Path(args.output_directory) / 'dmg',
-                         Path(args.output_directory).joinpath('shapes'),
+                         Path(args.output_directory).joinpath('shapes') / 'damage.shp',
                          args.destination_crs)
 
     # Complete

--- a/handler.py
+++ b/handler.py
@@ -276,25 +276,9 @@ def main():
 
     if args.create_shapefile:
         print('Creating shapefile')
-        files = get_files(Path(args.output_directory) / 'dmg')
-
-        polys = []
-        for idx, f in enumerate(files):
-            p = create_shapefile(f, Path(args.output_directory).joinpath('shapes'), idx)
-            polys.extend(p)
-
-        shp_schema = {
-            'geometry': 'MultiPolygon',
-            'properties': {'dmg': 'int'}
-        }
-
-        # Write out all the multipolygons to the same file
-        with fiona.open(args.output_directory.joinpath('shapes') / 'damage.shp', 'w', 'ESRI Shapefile', shp_schema, args.destination_crs) as shp:
-            for multipolygon, px_val in polys:
-                shp.write({
-                    'geometry': mapping(multipolygon),
-                    'properties': {'dmg': int(px_val)}
-                })
+        create_shapefile(Path(args.output_directory) / 'dmg',
+                         Path(args.output_directory).joinpath('shapes'),
+                         args.destination_crs)
 
     # Complete
     print('Run complete!')


### PR DESCRIPTION
Solves the grid issue which in hindsight was a result of the zero values being split there with the symbology showing the line. If a building falls on the intersection of the chips it will still be split into different polygons but this should look as users expect.